### PR TITLE
Adding in kustomization.yaml file to allow for easy K8s deployment

### DIFF
--- a/kubernetes-manifests/kustomization.yaml
+++ b/kubernetes-manifests/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- angular-frontend.yml
+- backend.yml
+- configuration-service.yml
+- loadgenerator.yml
+- mongodb-contentcreator.yml
+- mongodb.yml
+- nginx.yml


### PR DESCRIPTION
While the `./kubernetes-manifests/` directory had existed previously, there lacked a `kustomization.yaml` file which kubectl expects when supplying the `-k` flag.

![image](https://github.com/Dynatrace/easyTravel-Docker/assets/3068229/a60ce57c-7261-4e4b-a367-488ec0c7baab)


Now deploying easyTravel on K8s is as simple as:

1. Cloning this repo `git clone https://github.com/Dynatrace/easyTravel-Docker.git`
2. Creating the namespace (optional) `kubectl create namespace easytravel`
3. Deploying the K8s resources `kubectl apply -d ./kubernetes-manifests/ -n easytravel`